### PR TITLE
_config.yml for GitHub Pages, Gemfile, .gitignore, GFM backtick fenced code blocks 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+_site/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages'

--- a/README.md
+++ b/README.md
@@ -10,22 +10,37 @@ NOTE: This API documentation is also published, along with additional technical 
 ## Local Setup
 
 GitHub Pages websites being served through [Jekyll](http://jekyllrb.com/), you will need to replicate
-the setup on your local machine to preview the website locally.  If you don't have them already, install:
+the setup on your local machine to preview the website locally.
 
-- [Ruby](https://www.ruby-lang.org/en/documentation/installation/)
-- [Jekyll](http://jekyllrb.com/docs/installation/)
+If you don't have them already, install Ruby and Bundler by following the instructions [here](https://help.github.com/articles/setting-up-your-pages-site-locally-with-jekyll/).
 
-Once installed, `cd` to the repository directory and run Jekyll using the following command:
+Once cloned, `cd` to the repository directory and run
 
 ```
-$ cd express-api-docs
-$ jekyll s
+bundle install
+```
+
+Bundler will look in the Gemfile for which gems to install. The `github-pages` gem includes the same version of Jekyll and other dependencies as used by GitHub Pages, so that your local setup mirrors GitHub Pages as closely as possible.
+
+run Jekyll using the following command:
+
+```
+$ bundle exec jekyll serve
 ```
 
 Then, load [http://localhost:4000/](http://localhost:4000/) on your browser.
 
-Jekyll uses a variant of Markdown known as [Kramdown](http://kramdown.gettalong.org/quickref.html).
-Read up the docs if you need to go beyond basic Markdown in the doc files.
+Jekyll uses [Kramdown](http://kramdown.gettalong.org/quickref.html) which supports [GFM](http://kramdown.gettalong.org/parser/gfm.html).
+
+You can use GFM fenced code blocks for javascript in the docs. E.g.
+
+    ```js
+    var express = require('express');
+    var app = express();
+    app.listen(3000);
+    ```
+
+The default GitHub Pages syntax highlighting has been disabled in `_config.yml` to allow highlighting with prism.js.
 
 To understand the template system used by Jekyll, read the [Liquid template engine docs](http://liquidmarkup.org/).
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,9 @@
+# Site settings
+
+# Build settings
+markdown: kramdown
+
+kramdown:
+  input: GFM
+  syntax_highlighter_opts:
+    disable : true

--- a/_includes/api/en/4x/app-METHOD.md
+++ b/_includes/api/en/4x/app-METHOD.md
@@ -72,9 +72,9 @@ It loads middleware at a path for all request methods.
 In the following example, the handler is executed for requests to "/secret" whether using
 GET, POST, PUT, DELETE, or any other HTTP request method.
 
-{% highlight js %}
+```js
 app.all('/secret', function (req, res, next) {
   console.log('Accessing the secret section ...')
   next() // pass control to the next handler
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-all.md
+++ b/_includes/api/en/4x/app-all.md
@@ -16,21 +16,21 @@ that these callbacks do not have to act as end-points: `loadUser`
 can perform a task, then call `next()` to continue matching subsequent
 routes.
 
-{% highlight js %}
+```js
 app.all('*', requireAuthentication, loadUser);
-{% endhighlight %}
+```
 
 Or the equivalent:
 
-{% highlight js %}
+```js
 app.all('*', requireAuthentication)
 app.all('*', loadUser);
-{% endhighlight %}
+```
 
 Another example is white-listed "global" functionality.
 The example is similar to the ones above, but it only restricts paths that start with
 "/api":
 
-{% highlight js %}
+```js
 app.all('/api/*', requireAuthentication);
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-delete-method.md
+++ b/_includes/api/en/4x/app-delete-method.md
@@ -13,8 +13,8 @@ these callbacks can invoke `next('route')` to bypass the remaining route
 callback(s). You can use this mechanism to impose pre-conditions on a route, then pass control
 to subsequent routes if there's no reason to proceed with the current route.
 
-{% highlight js %}
+```js
 app.delete('/', function (req, res) {
   res.send('DELETE request to homepage');
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-disable.md
+++ b/_includes/api/en/4x/app-disable.md
@@ -10,8 +10,8 @@ Calling `app.set('foo', false)` for a Boolean property is the same as calling `a
 
 For example:
 
-{% highlight js %}
+```js
 app.disable('trust proxy');
 app.get('trust proxy');
 // => false
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-disabled.md
+++ b/_includes/api/en/4x/app-disabled.md
@@ -8,11 +8,11 @@
 Returns `true` if the Boolean setting `name` is disabled (`false`), where `name` is one of the properties from
 the [app settings table](#app.settings.table).
 
-{% highlight js %}
+```js
 app.disabled('trust proxy');
 // => true
 
 app.enable('trust proxy');
 app.disabled('trust proxy');
 // => false
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-enable.md
+++ b/_includes/api/en/4x/app-enable.md
@@ -8,8 +8,8 @@
 Sets the Boolean setting `name` to `true`, where `name` is one of the properties from the [app settings table](#app.settings.table).
 Calling `app.set('foo', true)` for a Boolean property is the same as calling `app.enable('foo')`.
 
-{% highlight js %}
+```js
 app.enable('trust proxy');
 app.get('trust proxy');
 // => true
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-enabled.md
+++ b/_includes/api/en/4x/app-enabled.md
@@ -8,11 +8,11 @@
 Returns `true` if the setting `name` is enabled (`true`), where `name` is one of the
 properties from the [app settings table](#app.settings.table).
 
-{% highlight js %}
+```js
 app.enabled('trust proxy');
 // => false
 
 app.enable('trust proxy');
 app.enabled('trust proxy');
 // => true
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-engine.md
+++ b/_includes/api/en/4x/app-engine.md
@@ -12,18 +12,18 @@ For example, if you try to render a "foo.jade" file, Express invokes the
 following internally, and caches the `require()` on subsequent calls to increase
 performance.
 
-{% highlight js %}
+```js
 app.engine('jade', require('jade').__express);
-{% endhighlight %}
+```
 
 Use this method for engines that do not provide `.__express` out of the box,
 or if you wish to "map" a different extension to the template engine.
 
 For example, to map the EJS template engine to ".html" files:
 
-{% highlight js %}
+```js
 app.engine('html', require('ejs').renderFile);
-{% endhighlight %}
+```
 
 In this case, EJS provides a `.renderFile()` method with
 the same signature that Express expects: `(path, options, callback)`,
@@ -34,8 +34,8 @@ Some template engines do not follow this convention.  The
 [consolidate.js](https://github.com/tj/consolidate.js) library maps Node template engines to follow this convention,
 so they work seamlessly with Express.
 
-{% highlight js %}
+```js
 var engines = require('consolidate');
 app.engine('haml', engines.haml);
 app.engine('html', engines.hogan);
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-get-method.md
+++ b/_includes/api/en/4x/app-get-method.md
@@ -13,8 +13,8 @@ these callbacks can invoke `next('route')` to bypass the remaining route callbac
 You can use this mechanism to impose pre-conditions on a route, then pass control to
 subsequent routes if there's no reason to proceed with the current route.
 
-{% highlight js %}
+```js
 app.get('/', function (req, res) {
   res.send('GET request to homepage');
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-get.md
+++ b/_includes/api/en/4x/app-get.md
@@ -8,11 +8,11 @@
 Returns the value of `name` app setting, where `name` is one of strings in the
 [app settings table](#app.settings.table). For example:
 
-{% highlight js %}
+```js
 app.get('title');
 // => undefined
 
 app.set('title', 'My Site');
 app.get('title');
 // => "My Site"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-listen.md
+++ b/_includes/api/en/4x/app-listen.md
@@ -8,11 +8,11 @@
 Binds and listens for connections on the specified host and port.
 This method is identical to Node's [http.Server.listen()](http://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback).
 
-{% highlight js %}
+```js
 var express = require('express');
 var app = express();
 app.listen(3000);
-{% endhighlight %}
+```
 
 The `app` returned by `express()` is in fact a JavaScript
 `Function`, designed to be passed to Node's HTTP servers as a callback
@@ -20,7 +20,7 @@ to handle requests. This makes it easy to provide both HTTP and HTTPS versions o
 your app with the same code base, as the app does not inherit from these
 (it is simply a callback):
 
-{% highlight js %}
+```js
 var express = require('express');
 var https = require('https');
 var http = require('http');
@@ -28,13 +28,13 @@ var app = express();
 
 http.createServer(app).listen(80);
 https.createServer(options, app).listen(443);
-{% endhighlight %}
+```
 
 The `app.listen()` method returns an [http.Server](https://nodejs.org/api/http.html#http_class_http_server) object and (for HTTP) is a convenience method for the following:
 
-{% highlight js %}
+```js
 app.listen = function() {
   var server = http.createServer(this);
   return server.listen.apply(server, arguments);
 };
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-locals.md
+++ b/_includes/api/en/4x/app-locals.md
@@ -7,13 +7,13 @@
 
 The `app.locals` object is has properties that are local variables within the application.
 
-{% highlight js %}
+```js
 app.locals.title
 // => 'My App'
 
 app.locals.email
 // => 'me@myapp.com'
-{% endhighlight %}
+```
 
 Once set, the value of `app.locals` properties persist throughout the life of the application,
 in contrast with [res.locals](#res.locals) properties that
@@ -23,8 +23,8 @@ You can access local variables in templates rendered within the application.
 This is useful for providing helper functions to templates, as well as application-level data.
 Local variables are available in middleware via `req.app.locals` (see [req.app](#req.app))
 
-{% highlight js %}
+```js
 app.locals.title = 'My App';
 app.locals.strftime = require('strftime');
 app.locals.email = 'me@myapp.com';
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-mountpath.md
+++ b/_includes/api/en/4x/app-mountpath.md
@@ -11,7 +11,7 @@ The `app.mountpath` property contains one or more path patterns on which a sub-a
   A sub-app is an instance of `express` that may be used for handling the request to a route.
 </div>
 
-{% highlight js %}
+```js
 var express = require('express');
 
 var app = express(); // the main app
@@ -23,7 +23,7 @@ admin.get('/', function (req, res) {
 });
 
 app.use('/admin', admin); // mount the sub app
-{% endhighlight %}
+```
 
 It is similar to the [baseUrl](#req.baseUrl) property of the `req` object, except `req.baseUrl`
 returns the matched URL path, instead of the matched patterns.
@@ -31,7 +31,7 @@ returns the matched URL path, instead of the matched patterns.
 If a sub-app is mounted on multiple path patterns, `app.mountpath` returns the list of
 patterns it is mounted on, as shown in the following example.
 
-{% highlight js %}
+```js
 var admin = express();
 
 admin.get('/', function (req, res) {
@@ -47,4 +47,4 @@ secret.get('/', function (req, res) {
 
 admin.use('/secr*t', secret); // load the 'secret' router on '/secr*t', on the 'admin' sub app
 app.use(['/adm*n', '/manager'], admin); // load the 'admin' router on '/adm*n' and '/manager', on the parent app
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-onmount.md
+++ b/_includes/api/en/4x/app-onmount.md
@@ -18,7 +18,7 @@ Sub-apps will:
 For details, see [Application settings](/en/4x/api.html#app.settings.table).
 </div>
 
-{% highlight js %}
+```js
 var admin = express();
 
 admin.on('mount', function (parent) {
@@ -31,4 +31,4 @@ admin.get('/', function (req, res) {
 });
 
 app.use('/admin', admin);
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-param.md
+++ b/_includes/api/en/4x/app-param.md
@@ -11,7 +11,7 @@ If `name` is an array, the `callback` trigger is registered for each parameter d
 
 For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
 
-{% highlight js %}
+```js
 app.param('user', function(req, res, next, id) {
 
   // try to get the user details from the User model and attach it to the request object
@@ -26,13 +26,13 @@ app.param('user', function(req, res, next, id) {
     }
   });
 });
-{% endhighlight %}
+```
 
 Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `app` will be triggered only by route parameters defined on `app` routes.
 
 All param callbacks will be called before any handler of any route in which the param occurs, and they will each be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
 
-{% highlight js %}
+```js
 app.param('id', function (req, res, next, id) {
   console.log('CALLED ONLY ONCE');
   next();
@@ -47,7 +47,7 @@ app.get('/user/:id', function (req, res) {
   console.log('and this matches too');
   res.end();
 });
-{% endhighlight %}
+```
 
 On `GET /user/42`, the following is printed:
 
@@ -57,7 +57,7 @@ although this matches
 and this matches too
 ```
 
-{% highlight js %}
+```js
 app.param(['id', 'page'], function (req, res, next, value) {
   console.log('CALLED ONLY ONCE with', value);
   next();
@@ -72,7 +72,7 @@ app.get('/user/:id/:page', function (req, res) {
   console.log('and this matches too');
   res.end();
 });
-{% endhighlight %}
+```
 
 On `GET /user/42/3`, the following is printed:
 
@@ -95,7 +95,7 @@ The middleware returned by the function decides the behavior of what happens whe
 
 In this example, the `app.param(name, callback)` signature is modified to `app.param(name, accessId)`. Instead of accepting a name and a callback, `app.param()` will now accept a name and a number.
 
-{% highlight js %}
+```js
 var express = require('express');
 var app = express();
 
@@ -122,11 +122,11 @@ app.get('/user/:id', function (req, res) {
 app.listen(3000, function () {
   console.log('Ready');
 });
-{% endhighlight %}
+```
 
 In this example, the `app.param(name, callback)` signature remains the same, but instead of a middleware callback, a custom data type checking function has been defined to validate the data type of the user id.
 
-{% highlight js %}
+```js
 app.param(function(param, validator) {
   return function (req, res, next, val) {
     if (validator(val)) {
@@ -141,7 +141,7 @@ app.param(function(param, validator) {
 app.param('id', function (candidate) {
   return !isNaN(parseFloat(candidate)) && isFinite(candidate);
 });
-{% endhighlight %}
+```
 
 <div class="doc-box doc-info" markdown="1">
 The '`.`' character can't be used to capture a character in your capturing regexp. For example you can't use `'/user-.+/'` to capture `'users-gami'`, use `[\\s\\S]` or `[\\w\\W]` instead (as in `'/user-[\\s\\S]+/'`.

--- a/_includes/api/en/4x/app-path.md
+++ b/_includes/api/en/4x/app-path.md
@@ -7,7 +7,7 @@
 
 Returns the canonical path of the app, a string.
 
-{% highlight js %}
+```js
 var app = express()
   , blog = express()
   , blogAdmin = express();
@@ -18,7 +18,7 @@ blog.use('/admin', blogAdmin);
 console.log(app.path()); // ''
 console.log(blog.path()); // '/blog'
 console.log(blogAdmin.path()); // '/blog/admin'
-{% endhighlight %}
+```
 
 The behavior of this method can become very complicated in complex cases of mounted apps:
 it is usually better to use [req.baseUrl](#req.baseUrl) to get the canonical path of the app.

--- a/_includes/api/en/4x/app-post-method.md
+++ b/_includes/api/en/4x/app-post-method.md
@@ -14,8 +14,8 @@ remaining route callback(s). You can use this mechanism to impose pre-conditions
 a route, then pass control to subsequent routes if there's no reason to proceed with
 the current route.
 
-{% highlight js %}
+```js
 app.post('/', function (req, res) {
   res.send('POST request to homepage');
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-put-method.md
+++ b/_includes/api/en/4x/app-put-method.md
@@ -14,8 +14,8 @@ remaining route callback(s). You can use this mechanism to impose pre-conditions
 a route, then pass control to subsequent routes if there's no reason to proceed with
 the current route.
 
-{% highlight js %}
+```js
 app.put('/', function (req, res) {
   res.send('PUT request to homepage');
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-render.md
+++ b/_includes/api/en/4x/app-render.md
@@ -19,7 +19,7 @@ The local variable `cache` is reserved for enabling view cache. Set it to `true`
 cache view during development; view caching is enabled in production by default.
 </div>
 
-{% highlight js %}
+```js
 app.render('email', function(err, html){
   // ...
 });
@@ -27,4 +27,4 @@ app.render('email', function(err, html){
 app.render('email', { name: 'Tobi' }, function(err, html){
   // ...
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-route.md
+++ b/_includes/api/en/4x/app-route.md
@@ -8,7 +8,7 @@
 Returns an instance of a single route, which you can then use to handle HTTP verbs with optional middleware.
 Use `app.route()` to avoid duplicate route names (and thus typo errors).
 
-{% highlight js %}
+```js
 var app = express();
 
 app.route('/events')
@@ -22,4 +22,4 @@ app.route('/events')
 .post(function(req, res, next) {
   // maybe add a new event...
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app-set.md
+++ b/_includes/api/en/4x/app-set.md
@@ -14,10 +14,10 @@ property is the same as calling `app.disable('foo')`.
 
 Retrieve the value of a setting with [`app.get()`](#app.get).
 
-{% highlight js %}
+```js
 app.set('title', 'My Site');
 app.get('title'); // "My Site"
-{% endhighlight %}
+```
 
 <h4 id='app.settings.table'>Application Settings</h4>
 

--- a/_includes/api/en/4x/app-use.md
+++ b/_includes/api/en/4x/app-use.md
@@ -16,7 +16,7 @@ If `path` is not specified, it defaults to "/".
 
 Note that `req.originalUrl` in a middleware function is a combination of `req.baseUrl` and `req.path`, as shown in the following example.
 
-{% highlight js %}
+```js
 app.use('/admin', function(req, res, next) {
   // GET 'http://www.example.com/admin/new'
   console.log(req.originalUrl); // '/admin/new'
@@ -24,19 +24,19 @@ app.use('/admin', function(req, res, next) {
   console.log(req.path); // '/new'
   next();
 });
-{% endhighlight %}
+```
 
 Mounting a middleware function at a `path` will cause the middleware function to be executed whenever the base of the requested path matches the `path`.
 
 Since `path` defaults to "/", middleware mounted without a path will be executed for every request to the app.
 
-{% highlight js %}
+```js
 // this middleware will be executed for every request to the app
 app.use(function (req, res, next) {
   console.log('Time: %d', Date.now());
   next();
 });
-{% endhighlight %}
+```
 
 <div class="doc-box doc-info" markdown="1">
 **NOTE**
@@ -51,7 +51,7 @@ For details, see [Application settings](/en/4x/api.html#app.settings.table).
 
 Middleware functions are executed sequentially, therefore the order of middleware inclusion is important.
 
-{% highlight js %}
+```js
 // this middleware will not allow the request to go beyond it
 app.use(function(req, res, next) {
   res.send('Hello World');
@@ -61,7 +61,7 @@ app.use(function(req, res, next) {
 app.get('/', function (req, res) {
   res.send('Welcome');
 });
-{% endhighlight %}
+```
 
 `path` can be a string representing a path, a path pattern, a regular expression to match paths,
 or an array of combinations thereof.
@@ -254,29 +254,29 @@ middleware in an Express app.
 
 Serve static content for the app from the "public" directory in the application directory:
 
-{% highlight js %}
+```js
 // GET /style.css etc
 app.use(express.static(__dirname + '/public'));
-{% endhighlight %}
+```
 
 Mount the middleware at "/static" to serve static content only when their request path is prefixed with "/static":
 
-{% highlight js %}
+```js
 // GET /static/style.css etc.
 app.use('/static', express.static(__dirname + '/public'));
-{% endhighlight %}
+```
 
 Disable logging for static content requests by loading the logger middleware after the static middleware:
 
-{% highlight js %}
+```js
 app.use(express.static(__dirname + '/public'));
 app.use(logger());
-{% endhighlight %}
+```
 
 Serve static files from multiple directories, but give precedence to "./public" over the others:
 
-{% highlight js %}
+```js
 app.use(express.static(__dirname + '/public'));
 app.use(express.static(__dirname + '/files'));
 app.use(express.static(__dirname + '/uploads'));
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/app.md
+++ b/_includes/api/en/4x/app.md
@@ -8,7 +8,7 @@
 The `app` object conventionally denotes the Express application.
 Create it by calling the top-level `express()` function exported by the Express module:
 
-{% highlight js %}
+```js
 var express = require('express');
 var app = express();
 
@@ -17,7 +17,7 @@ app.get('/', function(req, res){
 });
 
 app.listen(3000);
-{% endhighlight %}
+```
 
 The `app` object has methods for
 

--- a/_includes/api/en/4x/express.md
+++ b/_includes/api/en/4x/express.md
@@ -7,10 +7,10 @@
 
 Creates an Express application. The `express()` function is a top-level function exported by the `express` module.
 
-{% highlight js %}
+```js
 var express = require('express');
 var app = express();
-{% endhighlight %}
+```
 
 <h3 id='express.methods'>Methods</h3>
 

--- a/_includes/api/en/4x/express.router.md
+++ b/_includes/api/en/4x/express.router.md
@@ -7,9 +7,9 @@
 
 Creates a new [router](#router) object.
 
-{% highlight js %}
+```js
 var router = express.Router([options]);
-{% endhighlight %}
+```
 
 The optional `options` parameter specifies the behavior of the router.
 

--- a/_includes/api/en/4x/express.static.md
+++ b/_includes/api/en/4x/express.static.md
@@ -15,17 +15,17 @@ to move on to the next middleware, allowing for stacking and fall-backs.
 
 The following table describes the properties of the `options` object.
 
-| Property      | Description                                                           |   Type      | Default         |
-|---------------|-----------------------------------------------------------------------|-------------|-----------------|
-| `dotfiles`    | Determines how dotfiles (files or directories that begin with a dot ".") are treated.  <br/><br/>See [dotfiles](#dotfiles) below. | String | "ignore"|
-| `etag`        | Enable or disable etag generation  | Boolean | `true` |
-| `extensions`  | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`.| Boolean | `false` |
-| `fallthrough`  | Let client errors fall-through as unhandled requests, otherwise forward a client error. <br/><br/>See [fallthrough](#fallthrough) below.| Boolean | `true` |
-| `index`       | Sends the specified directory index file. Set to `false` to disable directory indexing. | Mixed | "index.html" |
-| `lastModified` | Set the `Last-Modified` header to the last modified date of the file on the OS. | Boolean | `true` |
-| `maxAge`      | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms). | Number | 0 |
-| `redirect`    | Redirect to trailing "/" when the pathname is a directory. | Boolean | `true` |
-| `setHeaders`  | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below. | Function |  |
+| Property       | Description                                                                                                                                                      | Type     | Default      |
+|:---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:-------------|
+| `dotfiles`     | Determines how dotfiles (files or directories that begin with a dot ".") are treated.  <br/><br/>See [dotfiles](#dotfiles) below.                                | String   | "ignore"     |
+| `etag`         | Enable or disable etag generation                                                                                                                                | Boolean  | `true`       |
+| `extensions`   | Sets file extension fallbacks: If a file is not found, search for files with the specified extensions and serve the first one found. Example: `['html', 'htm']`. | Boolean  | `false`      |
+| `fallthrough`  | Let client errors fall-through as unhandled requests, otherwise forward a client error. <br/><br/>See [fallthrough](#fallthrough) below.                         | Boolean  | `true`       |
+| `index`        | Sends the specified directory index file. Set to `false` to disable directory indexing.                                                                          | Mixed    | "index.html" |
+| `lastModified` | Set the `Last-Modified` header to the last modified date of the file on the OS.                                                                                  | Boolean  | `true`       |
+| `maxAge`       | Set the max-age property of the Cache-Control header in milliseconds or a string in [ms format](https://www.npmjs.org/package/ms).                               | Number   | 0            |
+| `redirect`     | Redirect to trailing "/" when the pathname is a directory.                                                                                                       | Boolean  | `true`       |
+| `setHeaders`   | Function for setting HTTP headers to serve with the file. <br/><br/>See [setHeaders](#setHeaders) below.                                                         | Function |              |
 
 For more information, see [Serving static files in Express](/starter/static-files.html).
 
@@ -58,9 +58,9 @@ For this option, specify a function to set custom response headers. Alterations 
 
 The signature of the function is:
 
-{% highlight js %}
+```js
 fn(res, path, stat)
-{% endhighlight %}
+```
 
 Arguments:
 

--- a/_includes/api/en/4x/req-accepts.md
+++ b/_includes/api/en/4x/req-accepts.md
@@ -13,7 +13,7 @@ The `type` value may be a single MIME type string (such as "application/json"),
 an extension name such as "json", a comma-delimited list, or an array. For a
 list or array, the method returns the *best* match (if any).
 
-{% highlight js %}
+```js
 // Accept: text/html
 req.accepts('html');
 // => "html"
@@ -36,6 +36,6 @@ req.accepts('png');
 // Accept: text/*;q=.5, application/json
 req.accepts(['html', 'json']);
 // => "json"
-{% endhighlight %}
+```
 
 For more information, or if you have issues or concerns, see [accepts](https://github.com/expressjs/accepts).

--- a/_includes/api/en/4x/req-app.md
+++ b/_includes/api/en/4x/req-app.md
@@ -12,14 +12,14 @@ and `require()` it in your main file, then the middleware can access the Express
 
 For example:
 
-{% highlight js %}
+```js
 //index.js
 app.get('/viewdirectory', require('./mymiddleware.js'))
-{% endhighlight %}
+```
 
-{% highlight js %}
+```js
 //mymiddleware.js
 module.exports = function (req, res) {
   res.send('The views directory is ' + req.app.get('views'));
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-baseUrl.md
+++ b/_includes/api/en/4x/req-baseUrl.md
@@ -12,7 +12,7 @@ except `app.mountpath` returns the matched path pattern(s).
 
 For example:
 
-{% highlight js %}
+```js
 var greet = express.Router();
 
 greet.get('/jp', function (req, res) {
@@ -21,15 +21,15 @@ greet.get('/jp', function (req, res) {
 });
 
 app.use('/greet', greet); // load the router on '/greet'
-{% endhighlight %}
+```
 
 Even if you use a path pattern or a set of path patterns to load the router,
 the `baseUrl` property returns the matched string, not the pattern(s). In the
 following example, the `greet` router is loaded on two path patterns.
 
-{% highlight js %}
+```js
 app.use(['/gre+t', '/hel{2}o'], greet); // load the router on '/gre+t' and '/hel{2}o'
-{% endhighlight %}
+```
 
 When a request is made to `/greet/jp`, `req.baseUrl` is "/greet".  When a request is
 made to `/hello/jp`, `req.baseUrl` is "/hello".

--- a/_includes/api/en/4x/req-body.md
+++ b/_includes/api/en/4x/req-body.md
@@ -11,7 +11,7 @@ as [body-parser](https://www.npmjs.org/package/body-parser) and [multer](https:/
 
 The following example shows how to use body-parsing middleware to populate `req.body`.
 
-{% highlight js %}
+```js
 var app = require('express')();
 var bodyParser = require('body-parser');
 var multer = require('multer'); // v1.0.5
@@ -24,4 +24,4 @@ app.post('/profile', upload.array(), function (req, res, next) {
   console.log(req.body);
   res.json(req.body);
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-cookies.md
+++ b/_includes/api/en/4x/req-cookies.md
@@ -8,10 +8,10 @@
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this property is an object that
 contains cookies sent by the request.  If the request contains no cookies, it defaults to `{}`.
 
-{% highlight js %}
+```js
 // Cookie: name=tj
 req.cookies.name
 // => "tj"
-{% endhighlight %}
+```
 
 For more information, issues, or concerns, see [cookie-parser](https://github.com/expressjs/cookie-parser).

--- a/_includes/api/en/4x/req-fresh.md
+++ b/_includes/api/en/4x/req-fresh.md
@@ -15,9 +15,9 @@ of the following are true:
 * The `if-none-match` request header, after being parsed into its directives, does not
 match the `etag` response header.
 
-{% highlight js %}
+```js
 req.fresh
 // => true
-{% endhighlight %}
+```
 
 For more information, issues, or concerns, see [fresh](https://github.com/jshttp/fresh).

--- a/_includes/api/en/4x/req-get.md
+++ b/_includes/api/en/4x/req-get.md
@@ -8,7 +8,7 @@
 Returns the specified HTTP request header field (case-insensitive match).
 The `Referrer` and `Referer` fields are interchangeable.
 
-{% highlight js %}
+```js
 req.get('Content-Type');
 // => "text/plain"
 
@@ -17,6 +17,6 @@ req.get('content-type');
 
 req.get('Something');
 // => undefined
-{% endhighlight %}
+```
 
 Aliased as `req.header(field)`.

--- a/_includes/api/en/4x/req-hostname.md
+++ b/_includes/api/en/4x/req-hostname.md
@@ -11,8 +11,8 @@ When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does no
 this property will instead have the value of the `X-Forwarded-Host` header field.
 This header can be set by the client or by the proxy.
 
-{% highlight js %}
+```js
 // Host: "example.com:3000"
 req.hostname
 // => "example.com"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-ip.md
+++ b/_includes/api/en/4x/req-ip.md
@@ -11,7 +11,7 @@ When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does no
 the value of this property is derived from the left-most entry in the
 `X-Forwarded-For` header. This header can be set by the client or by the proxy.
 
-{% highlight js %}
+```js
 req.ip
 // => "127.0.0.1"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-is.md
+++ b/_includes/api/en/4x/req-is.md
@@ -9,7 +9,7 @@ Returns `true` if the incoming request's "Content-Type" HTTP header field
 matches the MIME type specified by the `type` parameter.
 Returns `false` otherwise.
 
-{% highlight js %}
+```js
 // With Content-Type: text/html; charset=utf-8
 req.is('html');
 req.is('text/html');
@@ -24,6 +24,6 @@ req.is('application/*');
 
 req.is('html');
 // => false
-{% endhighlight %}
+```
 
 For more information, or if you have issues or concerns, see [type-is](https://github.com/expressjs/type-is).

--- a/_includes/api/en/4x/req-originalUrl.md
+++ b/_includes/api/en/4x/req-originalUrl.md
@@ -13,8 +13,8 @@ This property is much like `req.url`; however, it retains the original request U
 allowing you to rewrite `req.url` freely for internal routing purposes. For example,
 the "mounting" feature of [app.use()](#app.use) will rewrite `req.url` to strip the mount point.
 
-{% highlight js %}
+```js
 // GET /search?q=something
 req.originalUrl
 // => "/search?q=something"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-param.md
+++ b/_includes/api/en/4x/req-param.md
@@ -11,7 +11,7 @@ Deprecated. Use either `req.params`, `req.body` or `req.query`, as applicable.
 
 Returns the value of param `name` when present.
 
-{% highlight js %}
+```js
 // ?name=tobi
 req.param('name')
 // => "tobi"
@@ -23,7 +23,7 @@ req.param('name')
 // /user/tobi for /user/:name
 req.param('name')
 // => "tobi"
-{% endhighlight %}
+```
 
 Lookup is performed in the following order:
 

--- a/_includes/api/en/4x/req-params.md
+++ b/_includes/api/en/4x/req-params.md
@@ -7,16 +7,16 @@
 
 This property is an object containing properties mapped to the named route "parameters". For example, if you have the route `/user/:name`, then the "name" property is available as `req.params.name`. This object defaults to `{}`.
 
-{% highlight js %}
+```js
 // GET /user/tj
 req.params.name
 // => "tj"
-{% endhighlight %}
+```
 
 When you use a regular expression for the route definition, capture groups are provided in the array using `req.params[n]`, where `n` is the n<sup>th</sup> capture group. This rule is applied to unnamed wild card matches with string routes such as `/file/*`:
 
-{% highlight js %}
+```js
 // GET /file/javascripts/jquery.js
 req.params[0]
 // => "javascripts/jquery.js"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-path.md
+++ b/_includes/api/en/4x/req-path.md
@@ -7,11 +7,11 @@
 
 Contains the path part of the request URL.
 
-{% highlight js %}
+```js
 // example.com/users?sort=desc
 req.path
 // => "/users"
-{% endhighlight %}
+```
 
 <div class="doc-box doc-info" markdown="1">
 When called from a middleware, the mount point is not included in `req.path`. See [app.use()](/4x/api.html#app.use) for more details.

--- a/_includes/api/en/4x/req-protocol.md
+++ b/_includes/api/en/4x/req-protocol.md
@@ -11,7 +11,7 @@ When the [`trust proxy` setting](/4x/api.html#trust.proxy.options.table) does no
 this property will use the value of the `X-Forwarded-Proto` header field if present.
 This header can be set by the client or by the proxy.
 
-{% highlight js %}
+```js
 req.protocol
 // => "http"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-query.md
+++ b/_includes/api/en/4x/req-query.md
@@ -8,7 +8,7 @@
 This property is an object containing a property for each query string parameter in the route.
 If there is no query string, it is the empty object, `{}`.
 
-{% highlight js %}
+```js
 // GET /search?q=tobi+ferret
 req.query.q
 // => "tobi ferret"
@@ -22,4 +22,4 @@ req.query.shoe.color
 
 req.query.shoe.type
 // => "converse"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-route.md
+++ b/_includes/api/en/4x/req-route.md
@@ -7,16 +7,16 @@
 
 Contains the currently-matched route, a string.  For example:
 
-{% highlight js %}
+```js
 app.get('/user/:id?', function userIdHandler(req, res) {
   console.log(req.route);
   res.send('GET');
 });
-{% endhighlight %}
+```
 
 Example output from the previous snippet:
 
-{% highlight js %}
+```js
 { path: '/user/:id?',
   stack:
    [ { handle: [Function: userIdHandler],
@@ -27,4 +27,4 @@ Example output from the previous snippet:
        regexp: /^\/?$/i,
        method: 'get' } ],
   methods: { get: true } }
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-secure.md
+++ b/_includes/api/en/4x/req-secure.md
@@ -7,6 +7,6 @@
 
 A Boolean property that is true if a TLS connection is established. Equivalent to:
 
-{% highlight js %}
+```js
 'https' == req.protocol;
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-signedCookies.md
+++ b/_includes/api/en/4x/req-signedCookies.md
@@ -13,10 +13,10 @@ or encrypted; but simply prevents tampering (because the secret used to sign is 
 
 If no signed cookies are sent, the property defaults to `{}`.
 
-{% highlight js %}
+```js
 // Cookie: user=tobi.CP7AWaXDfAKIRfH49dQzKJx7sKzzSoPq7/AcBBRVwlI3
 req.signedCookies.user
 // => "tobi"
-{% endhighlight %}
+```
 
 For more information, issues, or concerns, see [cookie-parser](https://github.com/expressjs/cookie-parser).

--- a/_includes/api/en/4x/req-stale.md
+++ b/_includes/api/en/4x/req-stale.md
@@ -8,7 +8,7 @@
 Indicates whether the request is "stale," and is the opposite of `req.fresh`.
 For more information, see [req.fresh](#req.fresh).
 
-{% highlight js %}
+```js
 req.stale
 // => true
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-subdomains.md
+++ b/_includes/api/en/4x/req-subdomains.md
@@ -7,8 +7,8 @@
 
 An array of subdomains in the domain name of the request.
 
-{% highlight js %}
+```js
 // Host: "tobi.ferrets.example.com"
 req.subdomains
 // => ["ferrets", "tobi"]
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req-xhr.md
+++ b/_includes/api/en/4x/req-xhr.md
@@ -8,7 +8,7 @@
 A Boolean property that is `true` if the request's `X-Requested-With` header field is
 "XMLHttpRequest", indicating that the request was issued by a client library such as jQuery.
 
-{% highlight js %}
+```js
 req.xhr
 // => true
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/req.md
+++ b/_includes/api/en/4x/req.md
@@ -12,19 +12,19 @@ by the parameters to the callback function in which you're working.
 
 For example:
 
-{% highlight js %}
+```js
 app.get('/user/:id', function(req, res) {
   res.send('user ' + req.params.id);
 });
-{% endhighlight %}
+```
 
 But you could just as well have:
 
-{% highlight js %}
+```js
 app.get('/user/:id', function(request, response) {
   response.send('user ' + request.params.id);
 });
-{% endhighlight %}
+```
 
 <h3 id='req.properties'>Properties</h3>
 

--- a/_includes/api/en/4x/res-append.md
+++ b/_includes/api/en/4x/res-append.md
@@ -14,8 +14,8 @@ it creates the header with the specified value.  The `value` parameter can be a 
 
 Note: calling `res.set()` after `res.append()` will reset the previously-set header value.
 
-{% highlight js %}
+```js
 res.append('Link', ['<http://localhost/>', '<http://localhost:3000/>']);
 res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
 res.append('Warning', '199 Miscellaneous warning');
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-attachment.md
+++ b/_includes/api/en/4x/res-attachment.md
@@ -9,11 +9,11 @@ Sets the HTTP response `Content-Disposition` header field to "attachment". If a 
 then it sets the Content-Type based on the extension name via `res.type()`,
 and sets the `Content-Disposition` "filename=" parameter.
 
-{% highlight js %}
+```js
 res.attachment();
 // Content-Disposition: attachment
 
 res.attachment('path/to/logo.png');
 // Content-Disposition: attachment; filename="logo.png"
 // Content-Type: image/png
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-clearCookie.md
+++ b/_includes/api/en/4x/res-clearCookie.md
@@ -7,7 +7,7 @@
 
 Clears the cookie specified by `name`. For details about the `options` object, see [res.cookie()](#res.cookie).
 
-{% highlight js %}
+```js
 res.cookie('name', 'tobi', { path: '/admin' });
 res.clearCookie('name', { path: '/admin' });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-cookie.md
+++ b/_includes/api/en/4x/res-cookie.md
@@ -27,10 +27,10 @@ Any option not specified defaults to the value stated in [RFC 6265](http://tools
 
 For example:
 
-{% highlight js %}
+```js
 res.cookie('name', 'tobi', { domain: '.example.com', path: '/admin', secure: true });
 res.cookie('rememberme', '1', { expires: new Date(Date.now() + 900000), httpOnly: true });
-{% endhighlight %}
+```
 
 The `encode` option allows you to choose the function used for cookie value encoding.
 Does not support asynchronous functions.
@@ -38,7 +38,7 @@ Does not support asynchronous functions.
 Example use case: You need to set a domain-wide cookie for another site in your organization.
 This other site (not under your administrative control) does not use URI-encoded cookie values.
 
-{% highlight js %}
+```js
 //Default encoding
 res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com'});
 // Result: 'some_cross_domain_cookie=http%3A%2F%2Fmysubdomain.example.com; Domain=example.com; Path=/'
@@ -46,28 +46,28 @@ res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:
 //Custom encoding
 res.cookie('some_cross_domain_cookie', 'http://mysubdomain.example.com',{domain:'example.com', encode: String});
 // Result: 'some_cross_domain_cookie=http://mysubdomain.example.com; Domain=example.com; Path=/;'
-{% endhighlight %}
+```
 
 The `maxAge` option is a convenience option for setting "expires" relative to the current time in milliseconds.
 The following is equivalent to the second example above.
 
-{% highlight js %}
+```js
 res.cookie('rememberme', '1', { maxAge: 900000, httpOnly: true });
-{% endhighlight %}
+```
 
 You can pass an object as the `value` parameter; it is then serialized as JSON and parsed by `bodyParser()` middleware.
 
-{% highlight js %}
+```js
 res.cookie('cart', { items: [1,2,3] });
 res.cookie('cart', { items: [1,2,3] }, { maxAge: 900000 });
-{% endhighlight %}
+```
 
 When using [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware, this method also
 supports signed cookies. Simply include the `signed` option set to `true`.
 Then `res.cookie()` will use the secret passed to `cookieParser(secret)` to sign the value.
 
-{% highlight js %}
+```js
 res.cookie('name', 'tobi', { signed: true });
-{% endhighlight %}
+```
 
 Later you may access this value through the [req.signedCookie](#req.signedCookies) object.

--- a/_includes/api/en/4x/res-download.md
+++ b/_includes/api/en/4x/res-download.md
@@ -12,7 +12,7 @@ Override this default with the `filename` parameter.
 When an error ocurrs or transfer is complete, the method calls the optional callback function `fn`.
 This method uses [res.sendFile()](#res.sendFile) to transfer the file.
 
-{% highlight js %}
+```js
 res.download('/report-12345.pdf');
 
 res.download('/report-12345.pdf', 'report.pdf');
@@ -25,4 +25,4 @@ res.download('/report-12345.pdf', 'report.pdf', function(err){
     // decrement a download credit, etc.
   }
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-end.md
+++ b/_includes/api/en/4x/res-end.md
@@ -9,7 +9,7 @@ Ends the response process. This method actually comes from Node core, specifical
 
 Use to quickly end the response without any data. If you need to respond with data, instead use methods such as [res.send()](#res.send) and [res.json()](#res.json).
 
-{% highlight js %}
+```js
 res.end();
 res.status(404).end();
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-format.md
+++ b/_includes/api/en/4x/res-format.md
@@ -16,7 +16,7 @@ this within the callback using methods such as `res.set()` or `res.type()`.
 The following example would respond with `{ "message": "hey" }` when the `Accept` header field is set
 to "application/json" or "\*/json" (however if it is "\*/\*", then the response will be "hey").
 
-{% highlight js %}
+```js
 res.format({
   'text/plain': function(){
     res.send('hey');
@@ -35,12 +35,12 @@ res.format({
     res.status(406).send('Not Acceptable');
   }
 });
-{% endhighlight %}
+```
 
 In addition to canonicalized MIME types, you may also use extension names mapped
 to these types for a slightly less verbose implementation:
 
-{% highlight js %}
+```js
 res.format({
   text: function(){
     res.send('hey');
@@ -54,4 +54,4 @@ res.format({
     res.send({ message: 'hey' });
   }
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-get.md
+++ b/_includes/api/en/4x/res-get.md
@@ -8,7 +8,7 @@
 Returns the HTTP response header specified by `field`.
 The match is case-insensitive.
 
-{% highlight js %}
+```js
 res.get('Content-Type');
 // => "text/plain"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-headersSent.md
+++ b/_includes/api/en/4x/res-headersSent.md
@@ -7,10 +7,10 @@
 
 Boolean property that indicates if the app sent HTTP headers for the response.
 
-{% highlight js %}
+```js
 app.get('/', function (req, res) {
   console.log(res.headersSent); // false
   res.send('OK');
   console.log(res.headersSent); // true
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-json.md
+++ b/_includes/api/en/4x/res-json.md
@@ -9,8 +9,8 @@ Sends a JSON response. This method is identical to `res.send()` with an object o
 However, you can use it to convert other values to JSON, such as `null`, and `undefined` 
 (although these are technically not valid JSON).
 
-{% highlight js %}
+```js
 res.json(null);
 res.json({ user: 'tobi' });
 res.status(500).json({ error: 'message' });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-jsonp.md
+++ b/_includes/api/en/4x/res-jsonp.md
@@ -8,7 +8,7 @@
 Sends a JSON response with JSONP support. This method is identical to `res.json()`,
 except that it opts-in to JSONP callback support.
 
-{% highlight js %}
+```js
 res.jsonp(null);
 // => null
 
@@ -17,14 +17,14 @@ res.jsonp({ user: 'tobi' });
 
 res.status(500).jsonp({ error: 'message' });
 // => { "error": "message" }
-{% endhighlight %}
+```
 
 By default, the JSONP callback name is simply `callback`. Override this with the
 <a href="#app.settings.table">jsonp callback name</a> setting.
 
 The following are some examples of JSONP responses using the same code:
 
-{% highlight js %}
+```js
 // ?callback=foo
 res.jsonp({ user: 'tobi' });
 // => foo({ "user": "tobi" })
@@ -34,4 +34,4 @@ app.set('jsonp callback name', 'cb');
 // ?cb=foo
 res.status(500).jsonp({ error: 'message' });
 // => foo({ "error": "message" })
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-links.md
+++ b/_includes/api/en/4x/res-links.md
@@ -10,16 +10,16 @@ Joins the `links` provided as properties of the parameter to populate the respon
 
 For example, the following call:
 
-{% highlight js %}
+```js
 res.links({
   next: 'http://api.example.com/users?page=2',
   last: 'http://api.example.com/users?page=5'
 });
-{% endhighlight %}
+```
 
 Yields the following results:
 
-{% highlight js %}
+```js
 Link: <http://api.example.com/users?page=2>; rel="next",
       <http://api.example.com/users?page=5>; rel="last"
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-locals.md
+++ b/_includes/api/en/4x/res-locals.md
@@ -12,10 +12,10 @@ this property is identical to [app.locals](#app.locals).
 This property is useful for exposing request-level information such as the request path name,
 authenticated user, user settings, and so on.
 
-{% highlight js %}
+```js
 app.use(function(req, res, next){
   res.locals.user = req.user;
   res.locals.authenticated = ! req.user.anonymous;
   next();
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-location.md
+++ b/_includes/api/en/4x/res-location.md
@@ -7,11 +7,11 @@
 
 Sets the response `Location` HTTP header to the specified `path` parameter.
 
-{% highlight js %}
+```js
 res.location('/foo/bar');
 res.location('http://example.com');
 res.location('back');
-{% endhighlight %}
+```
 
 A `path` value of "back" has a special meaning, it refers to the URL specified in the `Referer` header of the request. If the `Referer` header was not specified, it refers to "/".
 

--- a/_includes/api/en/4x/res-redirect.md
+++ b/_includes/api/en/4x/res-redirect.md
@@ -9,32 +9,32 @@ Redirects to the URL derived from the specified `path`, with specified `status`,
 that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) .
 If not specified, `status` defaults to "302 "Found".
 
-{% highlight js %}
+```js
 res.redirect('/foo/bar');
 res.redirect('http://example.com');
 res.redirect(301, 'http://example.com');
 res.redirect('../login');
-{% endhighlight %}
+```
 Redirects can be a fully-qualified URL for redirecting to a different site:
 
-{% highlight js %}
+```js
 res.redirect('http://google.com');
-{% endhighlight %}
+```
 Redirects can be relative to the root of the host name. For example, if the
 application is on `http://example.com/admin/post/new`, the following
 would redirect to the URL `http://example.com/admin`:
 
-{% highlight js %}
+```js
 res.redirect('/admin');
-{% endhighlight %}
+```
 
 Redirects can be relative to the current URL. For example,
 from `http://example.com/blog/admin/` (notice the trailing slash), the following
 would redirect to the URL `http://example.com/blog/admin/post/new`.
 
-{% highlight js %}
+```js
 res.redirect('post/new');
-{% endhighlight %}
+```
 
 Redirecting to `post/new` from `http://example.com/blog/admin` (no trailing slash),
 will redirect to `http://example.com/blog/post/new`.
@@ -46,13 +46,13 @@ Path-relative redirects are also possible. If you were on
 `http://example.com/admin/post/new`, the following would redirect to
 `http//example.com/admin/post`:
 
-{% highlight js %}
+```js
 res.redirect('..');
-{% endhighlight %}
+```
 
 A `back` redirection redirects the request back to the [referer](http://en.wikipedia.org/wiki/HTTP_referer),
 defaulting to `/` when the referer is missing.
 
-{% highlight js %}
+```js
 res.redirect('back');
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-render.md
+++ b/_includes/api/en/4x/res-render.md
@@ -16,7 +16,7 @@ The local variable `cache` enables view caching. Set it to `true`,
 to cache the view during development; view caching is enabled in production by default.
 </div>
 
-{% highlight js %}
+```js
 // send the rendered view to the client
 res.render('index');
 
@@ -29,4 +29,4 @@ res.render('index', function(err, html) {
 res.render('user', { name: 'Tobi' }, function(err, html) {
   // ...
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-send.md
+++ b/_includes/api/en/4x/res-send.md
@@ -10,13 +10,13 @@ Sends the HTTP response.
 The `body` parameter can be a `Buffer` object, a `String`, an object, or an `Array`.
 For example:
 
-{% highlight js %}
+```js
 res.send(new Buffer('whoop'));
 res.send({ some: 'json' });
 res.send('<p>some html</p>');
 res.status(404).send('Sorry, we cannot find that!');
 res.status(500).send({ error: 'something blew up' });
-{% endhighlight %}
+```
 
 This method performs many useful tasks for simple non-streaming responses:
 For example, it automatically assigns the `Content-Length` HTTP response header field
@@ -25,20 +25,20 @@ For example, it automatically assigns the `Content-Length` HTTP response header 
 When the parameter is a `Buffer` object, the method sets the `Content-Type`
 response header field  to "application/octet-stream", unless previously defined as shown below:
 
-{% highlight js %}
+```js
 res.set('Content-Type', 'text/html');
 res.send(new Buffer('<p>some html</p>'));
-{% endhighlight %}
+```
 
 When the parameter is a `String`, the method sets the `Content-Type` to "text/html":
 
-{% highlight js %}
+```js
 res.send('<p>some html</p>');
-{% endhighlight %}
+```
 
 When the parameter is an `Array` or `Object`, Express responds with the JSON representation:
 
-{% highlight js %}
+```js
 res.send({ user: 'tobi' });
 res.send([1,2,3]);
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-sendFile.md
+++ b/_includes/api/en/4x/res-sendFile.md
@@ -34,7 +34,7 @@ ending the request-response cycle, or by passing control to the next route.
 
 Here is an example of using `res.sendFile` with all its arguments.
 
-{% highlight js %}
+```js
 app.get('/file/:name', function (req, res, next) {
 
   var options = {
@@ -58,12 +58,12 @@ app.get('/file/:name', function (req, res, next) {
   });
 
 });
-{% endhighlight %}
+```
 
 The following example illustrates using
 `res.sendFile` to provide fine-grained support for serving files:
 
-{% highlight js %}
+```js
 app.get('/user/:uid/photos/:file', function(req, res){
   var uid = req.params.uid
     , file = req.params.file;
@@ -76,5 +76,5 @@ app.get('/user/:uid/photos/:file', function(req, res){
     }
   });
 });
-{% endhighlight %}
+```
 For more information, or if you have issues or concerns, see [send](https://github.com/pillarjs/send).

--- a/_includes/api/en/4x/res-sendStatus.md
+++ b/_includes/api/en/4x/res-sendStatus.md
@@ -7,17 +7,17 @@
 
 Sets the response HTTP status code to `statusCode` and send its string representation as the response body.
 
-{% highlight js %}
+```js
 res.sendStatus(200); // equivalent to res.status(200).send('OK')
 res.sendStatus(403); // equivalent to res.status(403).send('Forbidden')
 res.sendStatus(404); // equivalent to res.status(404).send('Not Found')
 res.sendStatus(500); // equivalent to res.status(500).send('Internal Server Error')
-{% endhighlight %}
+```
 
 If an unsupported status code is specified, the HTTP status is still set to `statusCode` and the string version of the code is sent as the response body.
 
-{% highlight js %}
+```js
 res.sendStatus(2000); // equivalent to res.status(2000).send('2000')
-{% endhighlight %}
+```
 
 [More about HTTP Status Codes](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes)

--- a/_includes/api/en/4x/res-set.md
+++ b/_includes/api/en/4x/res-set.md
@@ -8,7 +8,7 @@
 Sets the response's HTTP header `field` to `value`.
 To set multiple fields at once, pass an object as the parameter.
 
-{% highlight js %}
+```js
 res.set('Content-Type', 'text/plain');
 
 res.set({
@@ -16,6 +16,6 @@ res.set({
   'Content-Length': '123',
   'ETag': '12345'
 });
-{% endhighlight %}
+```
 
 Aliased as `res.header(field [, value])`.

--- a/_includes/api/en/4x/res-status.md
+++ b/_includes/api/en/4x/res-status.md
@@ -8,8 +8,8 @@
 Sets the HTTP status for the response.
 It is a chainable alias of Node's [response.statusCode](http://nodejs.org/api/http.html#http_response_statuscode).
 
-{% highlight js %}
+```js
 res.status(403).end();
 res.status(400).send('Bad Request');
 res.status(404).sendFile('/absolute/path/to/404.png');
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-type.md
+++ b/_includes/api/en/4x/res-type.md
@@ -9,10 +9,10 @@ Sets the `Content-Type` HTTP header to the MIME type as determined by
 [mime.lookup()](https://github.com/broofa/node-mime#mimelookuppath) for the specified `type`.
 If `type` contains the "/" character, then it sets the `Content-Type` to `type`.
 
-{% highlight js %}
+```js
 res.type('.html');              // => 'text/html'
 res.type('html');               // => 'text/html'
 res.type('json');               // => 'application/json'
 res.type('application/json');   // => 'application/json'
 res.type('png');                // => image/png:
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res-vary.md
+++ b/_includes/api/en/4x/res-vary.md
@@ -7,6 +7,6 @@
 
 Adds the field to the `Vary` response header, if it is not there already.
 
-{% highlight js %}
+```js
 res.vary('User-Agent').render('docs');
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/res.md
+++ b/_includes/api/en/4x/res.md
@@ -13,19 +13,19 @@ by the parameters to the callback function in which you're working.
 
 For example:
 
-{% highlight js %}
+```js
 app.get('/user/:id', function(req, res){
   res.send('user ' + req.params.id);
 });
-{% endhighlight %}
+```
 
 But you could just as well have:
 
-{% highlight js %}
+```js
 app.get('/user/:id', function(request, response){
   response.send('user ' + request.params.id);
 });
-{% endhighlight %}
+```
 
 <h3 id='res.properties'>Properties</h3>
 

--- a/_includes/api/en/4x/router-METHOD.md
+++ b/_includes/api/en/4x/router-METHOD.md
@@ -22,20 +22,20 @@ to match incoming requests. Query strings are _not_ considered when performing
 these matches, for example "GET /" would match the following route, as would
 "GET /?name=tobi".
 
-{% highlight js %}
+```js
 router.get('/', function(req, res){
   res.send('hello world');
 });
-{% endhighlight %}
+```
 
 You can also use regular expressions&mdash;useful if you have very specific
 constraints, for example the following would match "GET /commits/71dbb9c" as well
 as "GET /commits/71dbb9c..4c084f9".
 
-{% highlight js %}
+```js
 router.get(/^\/commits\/(\w+)(?:\.\.(\w+))?$/, function(req, res){
   var from = req.params[0];
   var to = req.params[1] || 'HEAD';
   res.send('commit range ' + from + '..' + to);
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/router-all.md
+++ b/_includes/api/en/4x/router-all.md
@@ -16,21 +16,21 @@ that these callbacks do not have to act as end points; `loadUser`
 can perform a task, then call `next()` to continue matching subsequent
 routes.
 
-{% highlight js %}
+```js
 router.all('*', requireAuthentication, loadUser);
-{% endhighlight %}
+```
 
 Or the equivalent:
 
-{% highlight js %}
+```js
 router.all('*', requireAuthentication)
 router.all('*', loadUser);
-{% endhighlight %}
+```
 
 Another example of this is white-listed "global" functionality. Here
 the example is much like before, but it only restricts paths prefixed with
 "/api":
 
-{% highlight js %}
+```js
 router.all('/api/*', requireAuthentication);
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/router-param.md
+++ b/_includes/api/en/4x/router-param.md
@@ -20,7 +20,7 @@ Unlike `app.param()`, `router.param()` does not accept an array of route paramet
 
 For example, when `:user` is present in a route path, you may map user loading logic to automatically provide `req.user` to the route, or perform validations on the parameter input.
 
-{% highlight js %}
+```js
 router.param('user', function(req, res, next, id) {
 
   // try to get the user details from the User model and attach it to the request object
@@ -35,13 +35,13 @@ router.param('user', function(req, res, next, id) {
     }
   });
 });
-{% endhighlight %}
+```
 
 Param callback functions are local to the router on which they are defined. They are not inherited by mounted apps or routers. Hence, param callbacks defined on `router` will be triggered only by route parameters defined on `router` routes.
 
 A param callback will be called only once in a request-response cycle, even if the parameter is matched in multiple routes, as shown in the following examples.
 
-{% highlight js %}
+```js
 router.param('id', function (req, res, next, id) {
   console.log('CALLED ONLY ONCE');
   next();
@@ -56,7 +56,7 @@ router.get('/user/:id', function (req, res) {
   console.log('and this matches too');
   res.end();
 });
-{% endhighlight %}
+```
 
 On `GET /user/42`, the following is printed:
 
@@ -78,7 +78,7 @@ The middleware returned by the function decides the behavior of what happens whe
 
 In this example, the `router.param(name, callback)` signature is modified to `router.param(name, accessId)`. Instead of accepting a name and a callback, `router.param()` will now accept a name and a number.
 
-{% highlight js %}
+```js
 var express = require('express');
 var app = express();
 var router = express.Router();
@@ -108,11 +108,11 @@ app.use(router);
 app.listen(3000, function () {
   console.log('Ready');
 });
-{% endhighlight %}
+```
 
 In this example, the `router.param(name, callback)` signature remains the same, but instead of a middleware callback, a custom data type checking function has been defined to validate the data type of the user id.
 
-{% highlight js %}
+```js
 router.param(function(param, validator) {
   return function (req, res, next, val) {
     if (validator(val)) {
@@ -127,4 +127,4 @@ router.param(function(param, validator) {
 router.param('id', function (candidate) {
   return !isNaN(parseFloat(candidate)) && isFinite(candidate);
 });
-{% endhighlight %}
+```

--- a/_includes/api/en/4x/router-route.md
+++ b/_includes/api/en/4x/router-route.md
@@ -12,7 +12,7 @@ thus typo errors.
 Building on the `router.param()` example above, the following code shows how to use
 `router.route()` to specify various HTTP method handlers.
 
-{% highlight js %}
+```js
 var router = express.Router();
 
 router.param('user_id', function(req, res, next, id) {
@@ -45,7 +45,7 @@ router.route('/users/:user_id')
 .delete(function(req, res, next) {
   next(new Error('not implemented'));
 });
-{% endhighlight %}
+```
 
 This approach re-uses the single `/users/:user_id` path and add handlers for
 various HTTP methods.

--- a/_includes/api/en/4x/router-use.md
+++ b/_includes/api/en/4x/router-use.md
@@ -13,7 +13,7 @@ See [app.use()](#app.use) for more information.
 Middleware is like a plumbing pipe: requests start at the first middleware function defined
 and work their way "down" the middleware stack processing for each path they match.
 
-{% highlight js %}
+```js
 var express = require('express');
 var app = express();
 var router = express.Router();
@@ -39,7 +39,7 @@ router.use(function(req, res, next) {
 app.use('/foo', router);
 
 app.listen(3000);
-{% endhighlight %}
+```
 
 The "mount" path is stripped and is _not_ visible to the middleware function.
 The main effect of this feature is that a mounted middleware function may operate without
@@ -49,7 +49,7 @@ The order in which you define middleware with `router.use()` is very important.
 They are invoked sequentially, thus the order defines middleware precedence. For example,
 usually a logger is the very first middleware you would use, so that every request gets logged.
 
-{% highlight js %}
+```js
 var logger = require('morgan');
 
 router.use(logger());
@@ -57,28 +57,28 @@ router.use(express.static(__dirname + '/public'));
 router.use(function(req, res){
   res.send('Hello');
 });
-{% endhighlight %}
+```
 
 Now suppose you wanted to ignore logging requests for static files, but to continue
 logging routes and middleware defined after `logger()`.  You would simply move the call to `express.static()` to the top,
 before adding the logger middleware:
 
-{% highlight js %}
+```js
 router.use(express.static(__dirname + '/public'));
 router.use(logger());
 router.use(function(req, res){
   res.send('Hello');
 });
-{% endhighlight %}
+```
 
 Another example is serving files from multiple directories,
 giving precedence to "./public" over the others:
 
-{% highlight js %}
+```js
 app.use(express.static(__dirname + '/public'));
 app.use(express.static(__dirname + '/files'));
 app.use(express.static(__dirname + '/uploads'));
-{% endhighlight %}
+```
 
 The `router.use()` method also supports named parameters so that your mount points
 for other routers can benefit from preloading using named parameters.
@@ -88,24 +88,24 @@ they run is defined by the path they are attached to (not the router). Therefore
 middleware added via one router may run for other routers if its routes
 match. For example, this code shows two different routers mounted on the same path:
 
-{% highlight js %}
+```js
 var authRouter = express.Router();
 var openRouter = express.Router();
 
 authRouter.use(require('./authenticate').basic(usersdb));
 
-authRouter.get('/:user_id/edit', function(req, res, next) { 
+authRouter.get('/:user_id/edit', function(req, res, next) {
   // ... Edit user UI ...  
 });
-openRouter.get('/', function(req, res, next) { 
-  // ... List users ... 
+openRouter.get('/', function(req, res, next) {
+  // ... List users ...
 })
-openRouter.get('/:user_id', function(req, res, next) { 
-  // ... View user ... 
+openRouter.get('/:user_id', function(req, res, next) {
+  // ... View user ...
 })
 
 app.use('/users', authRouter);
 app.use('/users', openRouter);
-{% endhighlight %}
+```
 
 Even though the authentication middleware was added via the `authRouter` it will run on the routes defined by the `openRouter` as well since both routers were mounted on `/users`.  To avoid this behavior, use different paths for each router.

--- a/_includes/api/en/4x/router.md
+++ b/_includes/api/en/4x/router.md
@@ -18,7 +18,7 @@ The top-level `express` object has a [Router()](#express.router) method that cre
 Once you've created a router object, you can add middleware and HTTP method routes (such as `get`, `put`, `post`,
 and so on) to it just like an application.  For example:
 
-{% highlight js %}
+```js
 // invoked for any requests passed to this router
 router.use(function(req, res, next) {
   // .. some logic here .. like any other middleware
@@ -30,14 +30,14 @@ router.use(function(req, res, next) {
 router.get('/events', function(req, res, next) {
   // ..
 });
-{% endhighlight %}
+```
 
 You can then use a router for a particular root URL in this way separating your routes into files or even mini-apps.
 
-{% highlight js %}
+```js
 // only requests to /calendar/* will be sent to our "router"
 app.use('/calendar', router);
-{% endhighlight %}
+```
 
 
 </section>

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,0 @@
-# Site settings
-
-# Build settings
-markdown: kramdown


### PR DESCRIPTION
Hi expressjs docs maintainers,

If you want to keep using Jekyll, this PR should help you get Jekyll working locally

- The Gemfile enables `bundle install` to install Jekyll etc.
- Use `bundle exec jekyll serve` to run jekyll with watcher at localhost:4000
- The _config.yml  enables GFM so that you can use fenced code blocks (like the rest of GitHub)  
  It also disables the default Jekyll highlighting in favor of prism.js.
- the old `{% highlight js %} ... {% endhighlight %}` have been replaced with backticks
- See readme for more details

Also, see https://help.github.com/articles/user-organization-and-project-pages/
Not sure what git workflow you're planning to use, but you will need to use a `gh-pages` branch to publish on GitHub Pages with this "project" repo. An alternative would be to use the repo called `expressjs.github.io` in this eponymous org which would mean that the master branch is published on GitHub Pages. 

The benefit of Jekyll is that GitHub Pages will automatically re-generate the site when you commit markdown changes (on the gh-pages branch).

If you are ok with generating the site somewhere else, you can use any site generator (gulp, pub-server etc.) and then push just the HTML files to the gh-pages branch. In that case you'd maintain the markdown in a different branch or in a separate repo.

hth.